### PR TITLE
solve issue of low contrast

### DIFF
--- a/App/app/src/main/res/layout/fragment_operation.xml
+++ b/App/app/src/main/res/layout/fragment_operation.xml
@@ -20,7 +20,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="10dp"
             android:text="Warning: Do not use Skewy with headphones in ear."
-            android:textColor="@color/colorLightRed" />
+            android:textColor="#FF8F8F" />
 
         <TextView
             android:id="@+id/text_view_operation_play"


### PR DESCRIPTION
The original text color of the component is '#FF4040', and the contrast between the text color ('#FF404040') and the background color ('#424242') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#FF8F8F') are as follows:
![image](https://user-images.githubusercontent.com/101503193/185121254-de90b83c-5394-4bc7-9115-a9bee4a13216.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.